### PR TITLE
Fixed wrong inline-block rule

### DIFF
--- a/pathfinding_visualizer/src/App.css
+++ b/pathfinding_visualizer/src/App.css
@@ -9,11 +9,10 @@
   width:80%;
   margin: 5% 10% 5% 10%;
   text-align: center;
+  display: inline-block;
 }
 
 .RowContainer {
-  vertical-align: top;
-  display: inline-block;
   width: 80%;
   height: 20px;
   margin: 0px 10% 0px 10%;


### PR DESCRIPTION
Moved the declaration of `display: inline-block` from `.RowContainer` to `.GameContainer`. I also removed `vertical-align` which is no longer needed.