### PR TITLE
Fixed issue #18. Animation now stops when reset button is clicked.

### DIFF
--- a/pathfinding_visualizer/src/App.js
+++ b/pathfinding_visualizer/src/App.js
@@ -122,6 +122,7 @@ class Grid extends React.Component {
      *  It is called when the user presses the reset button
      */
 
+
     // Create a new empty grid as in ComponentDidMount
     const copygrid = [];
     let counter = 0;
@@ -145,6 +146,15 @@ class Grid extends React.Component {
 
     // Reset the color of nodes in the result path.
     this.state.path.forEach(resetNodeClass);
+
+    // Stop all animations
+    var id = window.setTimeout(function() {}, 0);
+
+    // This hack works bc timer IDs are consecutive integers. So we just need
+    // to get the latest timer id and decrement from it to get all timers.
+    while (id--) {
+        window.clearTimeout(id);
+    }
 
     // Reset the reset of the grid state
     this.setState({


### PR DESCRIPTION
Issue #18 : The `animate` function works by pushing a whole bunch of timer handlers onto the call-stack. JS then waits for the correct time before executing these handlers. However, clicking the reset button did not clear all animation timers on the call-stack that were waiting to be executed, so the animation still continued even after the button was pressed.

Approach: Find a way to clear all window timers on the call-stack that are still waiting to be executed.

Solution: Each call to `setTimeout` pushes a new timer handler with a unique timer id onto the call-stack. Traditionally, one can use `clearTimeout( <timerID> )` to clear a timer. But since we have a whole bunch, I used a hack found online: timer IDs are consecutive integers, so by creating a new timer with `setTimeout` (see line 151), we can get the latest timer ID. The rest of the IDs will just be everything from 0 up until this number.