### PR TITLE
Fixed lag when drawing walls with click-and-drag.

### DIFF
--- a/pathfinding_visualizer/src/App.js
+++ b/pathfinding_visualizer/src/App.js
@@ -55,9 +55,7 @@ class Grid extends React.Component {
 
   handleLongPress(event) {
     if (this.state.addingWalls){
-      this.buttonPressTimer = setTimeout(() => this.setState(prev => ({
-        drawingWalls: true,
-      })), 750);
+      this.setState({ drawingWalls: true });
     }
 	}
 
@@ -77,7 +75,6 @@ class Grid extends React.Component {
       });
     }
   }
-
 
   handleClick(key) {
     if (this.state.addingWalls) {


### PR DESCRIPTION
Fixed issue #21 

Removed time delay in `handleLongPress` by deleting the `setTimeout` handler used to update the state of `drawingWalls`