### PR TITLE
Changed handling of no path cases

### DIFF
--- a/pathfinding_visualizer/src/App.js
+++ b/pathfinding_visualizer/src/App.js
@@ -101,11 +101,21 @@ class Grid extends React.Component {
           const graph = new Graph();
           graph.gridtoGraph(this.state.grid);
           const result = graph.shortestPath(this.state.start, this.state.end);
-          if (result === null) {
-            this.setState({
-              phase: 4
+          if (!result[0].length) {
+            console.log("no path found");
+            const noPath = new Promise((resolve, reject) => {
+              resolve(this.animate(result));
+              reject("error");
             });
-            return;
+            noPath.then((success) => {
+              if (success) {
+                this.setState({
+                  phase:4
+                });
+              }
+            }, (failure) => {
+              console.log(failure);
+            });
           }
           // store the paths returned by Dijkstra's Algo
           this.setState({
@@ -230,7 +240,7 @@ class Grid extends React.Component {
 
     // After validating that all promises have been fulfilled (which means we
     // are done animating the search path), start animating the result path
-    Promise.all(promise_array).then(animate_result);
+    return(Promise.all(promise_array).then(animate_result).then(() => true));
   }
 
 

--- a/pathfinding_visualizer/src/Graph.js
+++ b/pathfinding_visualizer/src/Graph.js
@@ -56,8 +56,10 @@ export class Graph {
             }
 
         }
+        // if time to endNode is calculated as infinity, then no path exists from start node to end node
+        // hence path is an returned as an empty array 
         if (times[endNode.name] === Infinity) {
-            return null;
+            return [[], visited];
         }
         let path = [endNode.name];
         let lastVisited = endNode.name;


### PR DESCRIPTION
Now shows the search animation in cases where there is no possible path between start and end nodes before displaying the no path found status. 

This better simulates the algorithm failing to find a path to the end node.
